### PR TITLE
Fix "Synchronous operations are disallowed" issue

### DIFF
--- a/StatsRequestHandler.cs
+++ b/StatsRequestHandler.cs
@@ -96,11 +96,11 @@ public sealed class StatsRequestHandler
         writer.WriteEndObject();
     }
 
-    public Task GetNetworkStats(HttpContext context)
+    public async Task GetNetworkStats(HttpContext context)
     {
         var networkStats = _statsReporterFactory.GetNetworkStats();
 
-        using var writer = new Utf8JsonWriter(context.Response.Body);
+        await using var writer = new Utf8JsonWriter(context.Response.Body);
 
         writer.WriteStartObject();
 
@@ -125,9 +125,7 @@ public sealed class StatsRequestHandler
         }
 
         writer.WriteEndArray();
-        writer.WriteEndObject();
-
-        return Task.CompletedTask;
+        writer.WriteEndObject();        
     }
 
     public async Task ListReporters(HttpContext context)


### PR DESCRIPTION
Hi,
Thanks for the great project first :)
Currently one of our production services which is using this library is suffering from the issue mentioned below,
The root cause is because 
`GetNetworkStats` method of `StatsRequestHandler` class is using sync version of `Utf8JsonWriter`
This PR will make tiny changes so that method will use async version as like others

We have to do this in asp.net core apps because "Synchronous IO operations are disallowed" by default